### PR TITLE
Modify the contents of calling Pymategen module

### DIFF
--- a/aicon/elastic.py
+++ b/aicon/elastic.py
@@ -50,7 +50,7 @@ class ElasticConst(object):
         self.value_2 = self.tensor[0,1] + 2*self.tensor[3,3] + 3/5 * (self.tensor[0,0] - self.tensor[0,1] - 2*self.tensor[3,3])
         
         self.Stensor = inv(self.tensor)
-        struct = pmg.Structure.from_file(filepath + "POSCAR")
+        struct = pmg.core.Structure.from_file(filepath + "POSCAR")
         self.density = struct.density * 1e3                              #kg/m^3
         B_v = ((self.tensor[0,0] + self.tensor[1,1] + self.tensor[2,2]) + 2 * (self.tensor[0,1] + self.tensor[1,2] + self.tensor[2,0])) / 9
         G_v = ((self.tensor[0,0] + self.tensor[1,1] + self.tensor[2,2]) - (self.tensor[0,1] + self.tensor[1,2] + self.tensor[2,0]) \

--- a/aicon/myfiretasks.py
+++ b/aicon/myfiretasks.py
@@ -23,7 +23,7 @@
 import os
 import numpy as np
 from fireworks import explicit_serialize, FiretaskBase, FWAction
-from pymatgen import Structure
+from pymatgen.core import Structure
 from pymatgen.io.vasp.inputs import Incar
 from pymatgen.io.vasp.outputs import Oszicar,VaspParserError
 from pymatgen.io.vasp.sets import MPStaticSet, MPNonSCFSet, MPRelaxSet

--- a/aicon/myfireworks.py
+++ b/aicon/myfireworks.py
@@ -23,7 +23,7 @@
 from atomate.vasp.config import HALF_KPOINTS_FIRST_RELAX, RELAX_MAX_FORCE, \
     VASP_CMD, DB_FILE
 from fireworks import Firework
-from pymatgen import Structure
+from pymatgen.core import Structure
 from pymatgen.io.vasp.sets import MPRelaxSet, MPStaticSet
 from atomate.common.firetasks.glue_tasks import PassCalcLocs
 from atomate.vasp.firetasks.glue_tasks import CopyVaspOutputs, pass_vasp_result

--- a/aicon/phonon.py
+++ b/aicon/phonon.py
@@ -73,11 +73,11 @@ class Phonon(object):
     ''' Phonon related properties class. '''
     
     def __init__(self, filepath):
-        self.struct = pmg.Structure.from_file(filepath + 'POSCAR')
+        self.struct = pmg.core.Structure.from_file(filepath + 'POSCAR')
         self.M_avg = 0.0
         
         for ele in self.struct.symbol_set:
-            self.M_avg = self.M_avg + pmg.Element(ele).atomic_mass * self.struct.composition.get_atomic_fraction(ele)
+            self.M_avg = self.M_avg + pmg.core.Element(ele).atomic_mass * self.struct.composition.get_atomic_fraction(ele)
     
         self.M_avg = atommass * self.M_avg             
         self.V_avg = self.struct.volume/self.struct.composition.num_atoms * 1e-30  

--- a/aicon/tools.py
+++ b/aicon/tools.py
@@ -44,7 +44,7 @@ def Generate_kpoints(struct, kppa):
     
     Parameters:
     ----------
-    struct: pmg.structure object
+    struct: pmg.core.structure object
     kppa: float
         The grid resolution in the reciprocal space, the unit is A-1. 
     '''
@@ -66,7 +66,7 @@ def Generate_kpoints(struct, kppa):
 def get_highsympath(filename):
     ''' Get the high symmetry path of phonon spectrum. '''
     
-    struct = pmg.Structure.from_file(filename)       
+    struct = pmg.core.Structure.from_file(filename)       
     finder = SpacegroupAnalyzer(struct)
     prims = finder.get_primitive_standard_structure()
     HKpath = HighSymmKpath(struct)
@@ -138,7 +138,7 @@ def get_sym_eq_kpoints(struct, kpoint, cartesian=False, tol=1e-2):
 def get_highsymweight(filename):
     ''' Get the multiplicity of the high symmetry path. '''
     
-    struct = pmg.Structure.from_file(filename)       
+    struct = pmg.core.Structure.from_file(filename)       
     HKpath = HighSymmKpath(struct)
     Keys = list()
     Coords = list()
@@ -412,7 +412,7 @@ def calc_MFPS(Elem_tabl):
     '''Calculate mass fluctuation phonon scattering parameter. '''
     
     tab_len  = len(Elem_tabl)
-    Mass = [pmg.Element[Elem_tabl[i]].atomic_mass for i in np.arange(tab_len)]
+    Mass = [pmg.core.Element[Elem_tabl[i]].atomic_mass for i in np.arange(tab_len)]
     MassSum = np.sum(Mass)
     MFPS = 0.0
     

--- a/examples/Electron/createelecworkflow.py
+++ b/examples/Electron/createelecworkflow.py
@@ -5,7 +5,7 @@ Created on Mon Jun 15 11:20:45 2020
 @author: Tao.Fan
 """
 import numpy as np
-from pymatgen import Structure
+from pymatgen.core import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from aicon.myworkflow import wf_electron_conductivity
 from fireworks import LaunchPad

--- a/examples/Phonon/createphonworkflow.py
+++ b/examples/Phonon/createphonworkflow.py
@@ -5,7 +5,7 @@ Created on Mon Jun 15 11:20:45 2020
 @author: Tao.Fan
 """
 import numpy as np
-from pymatgen import Structure
+from pymatgen.core import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from aicon.myworkflow import wf_phonon_conductivity
 from fireworks import LaunchPad


### PR DESCRIPTION
Run AICON example:
```shell
#~/AICON2/examples/Phonon/C
AICON --phon --tmin 300 --tmax 1000 --tstep 50
```
it prompt: 
> AttributeError: module 'pymatgen' has no attribute 'structure'

Bcz some APIs of pymategen had been changed: 

pymategen.Element  --->  pymategen.core.Element
pymategen.Structure ---> pymategen.core.Structure

ref: https://pymatgen.org/usage.html.
